### PR TITLE
protection bugfixes.

### DIFF
--- a/keepass/kdb4.py
+++ b/keepass/kdb4.py
@@ -329,7 +329,7 @@ class KDBXmlExtension:
         Returns the next section of the "random" Salsa20 bytes with the 
         requested `length`.
         """
-        if length > len(self._salsa_buffer):
+        while length > len(self._salsa_buffer):
             new_salsa = self.salsa.encryptBytes(str(bytearray(64)))
             self._salsa_buffer.extend(new_salsa)
         nacho = self._salsa_buffer[:length]

--- a/keepass/kdb4.py
+++ b/keepass/kdb4.py
@@ -284,9 +284,10 @@ class KDBXmlExtension:
         self._reset_salsa()
         self.obj_root.Meta.MemoryProtection.ProtectPassword._setText('False')
         for elem in self.obj_root.iterfind('.//Value[@Protected="True"]'):
-            elem.set('ProtectedValue', elem.text)
-            elem.set('Protected', 'False')
-            elem._setText(self._unprotect(elem.text))
+            if elem.text is not None:
+                elem.set('ProtectedValue', elem.text)
+                elem.set('Protected', 'False')
+                elem._setText(self._unprotect(elem.text))
 
     def protect(self):
         """


### PR DESCRIPTION
Salsa20 only works in 64Byte blocks. When a protected string is larger than the salsa20 buffer, it would need to be extended.
Extension would only extend _once_ with 64Bytes instead of extending until we have enough Bytes to correctly XOR.

Second problem is that we'd try to unprotect empty tags, leading to errors in the xml parser as the elem.text is defined as the None type.
